### PR TITLE
Associate named user by email

### DIFF
--- a/docs/named_user.rst
+++ b/docs/named_user.rst
@@ -40,6 +40,23 @@ Associate a channel with a named user ID. For more information, see
 
     Do not include a ``device_type`` for Web and Open platform associations.
 
+Association by email
+-----------
+
+Associate an email with a named user ID. For more information, see
+`the API documentation
+<http://docs.airship.com/api/ua.html#association>`__
+
+.. code-block:: ruby
+
+    require 'urbanairship'
+    UA = Urbanairship
+    airship = UA::Client.new(key:'application_key', secret:'app_or_master_secret')
+    named_user = UA::NamedUser.new(client: airship)
+    named_user.named_user_id = 'named_user'
+    named_user.associate_by_email_address(email_address: 'email_address')
+
+
 Disassociation
 --------------
 

--- a/lib/urbanairship/devices/named_user.rb
+++ b/lib/urbanairship/devices/named_user.rb
@@ -42,6 +42,24 @@ module Urbanairship
         response
       end
 
+      def associate_by_email_address(email_address: required('email_address'))
+        fail ArgumentError,
+             'named_user_id is required for association' if @named_user_id.nil?
+
+        payload = {}
+        payload['email_address'] = email_address
+        payload['named_user_id'] = @named_user_id.to_s
+
+        response = @client.send_request(
+          method: 'POST',
+          body: JSON.dump(payload),
+          path: named_users_path('associate'),
+          content_type: CONTENT_TYPE
+        )
+        logger.info { "Associated email_address #{email_address} with named_user #{@named_user_id}" }
+        response
+      end
+
       def disassociate(channel_id: required('channel_id'), device_type: nil)
         payload = {}
         payload['channel_id'] = channel_id


### PR DESCRIPTION
We were recommended by the Airship support to change the way we associate email channels with named user IDs. This operation is not currently supported by the Airship's Ruby Library, so we decided to add it to our fork.

Connects to the issue: https://github.com/OLIOEX/community-team/issues/1188

https://docs.airship.com/api/ua/index.html#operation-api-named_users-associate-post